### PR TITLE
Add required_ruby_version to gemspec

### DIFF
--- a/apns-persistent.gemspec
+++ b/apns-persistent.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.1.0'
+
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
Because keyword arguments which has no default value can not work in ruby 2.0.0.

https://github.com/malt03/apns-persistent/blob/master/lib/apns/persistent/client.rb#L10-L13
